### PR TITLE
153/maintenance mode

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -1,13 +1,11 @@
 name: bee
 recipe: backdrop
 config:
-  php: 7.2
+  php: 7.4
   webroot: backdrop
   database: mariadb
-  # Although Drush isn't needed/used, the version that Lando includes by default
-  # has a bug that causes all build steps to fail. We therefore need to update
-  # Drush to the latest version just to make sure that build steps run properly.
-  backdrush: 1.x-1.x
+  backdrush: '1.x-1.x'
+
 services:
   appserver:
     build:
@@ -22,7 +20,7 @@ services:
       # Run setup tasks.
       - /app/.lando/setup.sh setup
   multisite:
-    type: php:7.2
+    type: php:7.4
     webroot: multisite
 events:
   pre-rebuild:

--- a/commands/state.bee.inc
+++ b/commands/state.bee.inc
@@ -34,6 +34,18 @@ function state_bee_command() {
         'bee state-set maintanance_mode 1' => bt('Set the value of the Backdrop state named "maintanance_mode" to 1.'),
       ],
     ],
+    'maintenance-mode' => [
+      'description' => bt('Set the value of maintenance_mode for Backdrop.'),
+      'callback' => 'maintenance_mode_bee_callback',
+      'arguments' => [
+        'value' => bt('The value to set maintenance_mode to.'),
+      ],
+      'aliases' => ['mm',],
+      'bootstrap' => BEE_BOOTSTRAP_FULL,
+      'examples' => [
+        'bee maintanance-mode 1' => bt('Set the value of the Backdrop maintenance_mode to 1.'),
+      ],
+    ],
   ];
 }
 
@@ -69,7 +81,7 @@ function state_set_bee_callback($arguments, $options) {
       '@state' => $arguments['state'],
       '@value' => $arguments['value'],
     ]);
-    bee_message($msg);
+    bee_message($msg, 'success');
   }
   catch(ParseError $e) {
     // This is more readable than the default error we would get from PHP.
@@ -80,3 +92,24 @@ function state_set_bee_callback($arguments, $options) {
     bee_message($err_msg, 'error');
   }
 }
+
+  /**
+   * Command callback: Set the value of a maintenance_mode for Backdrop.
+   */
+  function maintenance_mode_bee_callback($arguments, $options) {
+    try {
+      state_set('maintenance_mode', (int) $arguments['value']);
+      $msg = bt('The value of the Backdrop maintenance_mode is "@value".', [
+        '@value' => $arguments['value'],
+      ]);
+      bee_message($msg, 'success');
+    }
+    catch(ParseError $e) {
+      // This is more readable than the default error we would get from PHP.
+      $err_msg = bt('!msg in: !value', array(
+        '!msg' => $e->getMessage(),
+        '!value' => $arguments['value'],
+      ));
+      bee_message($err_msg, 'error');
+    }
+  }

--- a/commands/state.bee.inc
+++ b/commands/state.bee.inc
@@ -1,0 +1,82 @@
+<?php
+/**
+ * @file
+ * Command(s) for getting and setting backdrop states.
+ */
+
+/**
+ * Implements hook_bee_command().
+ */
+function state_bee_command() {
+  return [
+    'state-get' => [
+      'description' => bt('Get the value of a Backdrop state.'),
+      'callback' => 'state_get_bee_callback',
+      'arguments' => [
+        'state' => bt('The name of the state to get.'),
+      ],
+      'aliases' => ['sg, sget'],
+      'bootstrap' => BEE_BOOTSTRAP_FULL,
+      'examples' => [
+        'bee state-get maintanance_mode' => bt('Get the value of the Backdrop state named "maintanance_mode".'),
+      ],
+    ],
+    'state-set' => [
+      'description' => bt('Set the value of a Backdrop state.'),
+      'callback' => 'state_set_bee_callback',
+      'arguments' => [
+        'state' => bt('The name of the state to set.'),
+        'value' => bt('The value to set the state to.'),
+      ],
+      'aliases' => ['ss, sset'],
+      'bootstrap' => BEE_BOOTSTRAP_FULL,
+      'examples' => [
+        'bee state-set maintanance_mode 1' => bt('Set the value of the Backdrop state named "maintanance_mode" to 1.'),
+      ],
+    ],
+  ];
+}
+
+/**
+ * Command callback: Get the value of a Backdrop state.
+ */
+function state_get_bee_callback($arguments, $options) {
+  try {
+    $value = state_get($arguments['state']);
+    $msg = bt('The value of the Backdrop state named "@state" is "@value".', [
+      '@state' => $arguments['state'],
+      '@value' => $value,
+    ]);
+    bee_message($msg, 'status');
+  }
+  catch(ParseError $e) {
+    // This is more readable than the default error we would get from PHP.
+    $err_msg = bt('!msg in: !state', array(
+      '!msg' => $e->getMessage(),
+      '!state' => $arguments['state'],
+    ));
+    bee_message($err_msg, 'error');
+  }
+}
+
+/**
+ * Command callback: Set the value of a Backdrop state.
+ */
+function state_set_bee_callback($arguments, $options) {
+  try {
+    state_set($arguments['state'], (int) $arguments['value']);
+    $msg = bt('The value of the Backdrop state named "@state" is "@value".', [
+      '@state' => $arguments['state'],
+      '@value' => $arguments['value'],
+    ]);
+    bee_message($msg);
+  }
+  catch(ParseError $e) {
+    // This is more readable than the default error we would get from PHP.
+    $err_msg = bt('!msg in: !state', array(
+      '!msg' => $e->getMessage(),
+      '!state' => $arguments['state'],
+    ));
+    bee_message($err_msg, 'error');
+  }
+}

--- a/tests/backdrop/StateCommandsTest.php
+++ b/tests/backdrop/StateCommandsTest.php
@@ -28,4 +28,16 @@ class StateCommandsTest extends TestCase {
     $output = shell_exec('bee state-set maintenance_mode 1');
     $this->assertStringContainsString('1', $output);
   }
+
+    /**
+   * Make sure that the maintenance-mode command works.
+   */
+  public function test_maintenance_mode_command_works() {
+    $output = shell_exec('bee maintenance_mode 1');
+    $this->assertStringContainsString('maintenance_mode', $output);
+    $this->assertStringContainsString('1', $output);
+
+    $output = shell_exec('bee state-set maintenance_mode 0');
+    $this->assertStringContainsString('0', $output);
+  }
 }

--- a/tests/backdrop/StateCommandsTest.php
+++ b/tests/backdrop/StateCommandsTest.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * @file
+ * PHPUnit tests for Bee State commands.
+ */
+
+use PHPUnit\Framework\TestCase;
+
+class StateCommandsTest extends TestCase {
+
+  /**
+   * Make sure that the state-get command works.
+   */
+  public function test_state_get_command_works() {
+    $output_all = shell_exec('bee state-get maintenance_mode');
+    $this->assertStringContainsString('0', $output_all);
+    $this->assertStringContainsString('maintenance_mode', $output_all);
+  }
+
+  /**
+   * Make sure that the state-set command works.
+   */
+  public function test_state_set_command_works() {
+    $output = shell_exec('bee state-get maintenance_mode');
+    $this->assertStringContainsString('maintenance_mode', $output);
+    $this->assertStringContainsString('0', $output);
+
+    $output = shell_exec('bee state-set maintenance_mode 1');
+    $this->assertStringContainsString('1', $output);
+  }
+}

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -4,6 +4,7 @@
       <file>backdrop/BeeCoreTest.php</file>
       <file>backdrop/CacheCommandsTest.php</file>
       <file>backdrop/ConfigCommandsTest.php</file>
+      <file>backdrop/StateCommandsTest.php</file>
       <file>backdrop/CronCommandsTest.php</file>
       <file>backdrop/DBCommandsTest.php</file>
       <file>backdrop/DBLogCommandsTest.php</file>


### PR DESCRIPTION
Adding commands:

* `bee state-get <STATE>`
* `bee state-set <STATE> <VALUE>`
*  `bee maintenance-mode <VALUE>`

```bash
➜  backdrop git:(153/maintenance-mode) ✗ lando bee help state-get
state-get, sg, sget
Get the value of a Backdrop state.

Arguments:
 state   The name of the state to get. 

Examples:
 bee state-get maintanance_mode   Get the value of the Backdrop state named "maintanance_mode". 

➜  backdrop git:(153/maintenance-mode) ✗ lando bee help state-set
state-set, ss, sset
Set the value of a Backdrop state.

Arguments:
 state   The name of the state to set.  
 value   The value to set the state to. 

Examples:
 bee state-set maintanance_mode 1   Set the value of the Backdrop state named "maintanance_mode" to 1. 

➜  backdrop git:(153/maintenance-mode) ✗ lando bee help maintenance-mode
maintenance-mode, mm
Set the value of maintenance_mode for Backdrop.

Arguments:
 value   The value to set maintenance_mode to. 

Examples:
 bee maintanance-mode 1   Set the value of the Backdrop maintenance_mode to 1. 
```