### PR TITLE
Add sql-drop command for dropping and re-creating databases.

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+# Added for people using VSCode whose .inc files are caught by
+# prettier and munged. Good for people who do JS and PHP dev.
+*.inc

--- a/bee.php
+++ b/bee.php
@@ -41,7 +41,7 @@ exit();
  *
  * @see https://www.php.net/manual/en/function.set-error-handler.php
  */
-function bee_error_handler($errno, $message, $filename, $line, $context) {
+function bee_error_handler($errno, $message, $filename, $line, $context = []) {
   if (error_reporting() > 0) {
     echo "$message\n";
     echo " $filename:$line\n\n";

--- a/bee.php
+++ b/bee.php
@@ -43,7 +43,17 @@ exit();
  */
 function bee_error_handler($errno, $message, $filename, $line, $context = []) {
   if (error_reporting() > 0) {
-    echo "$message\n";
-    echo " $filename:$line\n\n";
+    switch ($errno) {
+      case E_ERROR:
+      case E_CORE_ERROR:
+      case E_COMPILE_ERROR:
+      case E_USER_ERROR:
+        bee_render_text(array('value' => "ERROR: ", '#color' => 'red', '#bold' => TRUE), FALSE);
+        bee_render_text(array('value' => $message, '#color' => 'yellow'), TRUE);
+        bee_render_text(array('value' => "       In: $filename, Line: $line\n", '#color' => 'cyan', '#bold' => TRUE), TRUE);
+        break;
+      default:
+        break;
+    }
   }
 }

--- a/commands/db.bee.inc
+++ b/commands/db.bee.inc
@@ -36,6 +36,15 @@ function db_bee_command() {
         'bee db-import db.sql.gz' => bt('Extract and import db.sql into the current database.'),
       ),
     ),
+    'db-drop' => array(
+      'description' => bt('Drop the current backdrop database'),
+      'callback' => 'db_drop_bee_callback',
+      'aliases' => array('sql-drop', 'dbd'),
+      'bootstrap' => BEE_BOOTSTRAP_DATABASE,
+      'examples' => array(
+        'bee sql-drop' => bt('Drop the existing backdrop database. Used when wanting to re-import fresh.'),
+      ),
+    ),
     'sql' => array(
       'description' => bt("Open an SQL command-line interface using Backdrop's database credentials."),
       'callback' => 'sql_bee_callback',
@@ -47,6 +56,48 @@ function db_bee_command() {
       ),
     ),
   );
+}
+
+/**
+ * Command callback: Drop and re-create the existing configured database.
+ */
+function db_drop_bee_callback($arguments, $options) {
+  // Initialize our pipes variable.
+  $pipes = array();
+
+  // Get database info.
+  $db_connection = Database::getConnectionInfo();
+  $db_info = $db_connection['default'];
+
+  // Drop the existing backdrop database as configured.
+  $command = 'mysql --user=' . $db_info['username'] . ' --password=' . $db_info['password'] . ' --host=' . $db_info['host'] . ' -e "drop database ' . $db_info['database'] . '"';
+  $result = proc_close(proc_open($command, array(STDIN, STDOUT, STDERR), $pipes));
+
+  if ($result == -1) {
+    bee_message(bt("The '!database' database could not be dropped.", array(
+      '!database' => $db_info['database'],
+    )), 'error');
+  }
+  else {
+    bee_message(bt("The '!database' database was successfully dropped.", array(
+      '!database' => $db_info['database'],
+    )), 'success');
+  }
+
+  // Re-create the existing backdrop database as configured.
+  $command = 'mysql --user=' . $db_info['username'] . ' --password=' . $db_info['password'] . ' --host=' . $db_info['host'] . ' -e "create database ' . $db_info['database'] . '"';
+  $result = proc_close(proc_open($command, array(STDIN, STDOUT, STDERR), $pipes));
+
+  if ($result == -1) {
+    bee_message(bt("The '!database' database could not be created.", array(
+      '!database' => $db_info['database'],
+    )), 'error');
+  }
+  else {
+    bee_message(bt("The '!database' database was successfully created.", array(
+      '!database' => $db_info['database'],
+    )), 'success');
+  }
 }
 
 /**

--- a/commands/version.bee.inc
+++ b/commands/version.bee.inc
@@ -1,0 +1,28 @@
+<?php
+/**
+ * @file
+ * The command for displaying the current version of Bee.
+ */
+
+/**
+ * Implements hook_bee_command().
+ */
+function version_bee_command() {
+  return array(
+    'version' => array(
+      'description' => bt('Display the current version of Bee.'),
+      'callback' => 'version_bee_callback',
+      'examples' => array(
+        'bee version' => bt('Output the current version.'),
+      ),
+    ),
+  );
+}
+
+/**
+ * Command callback: Run cron.
+ */
+function version_bee_callback($arguments, $options) {
+  $current_version = BEE_VERSION;
+  bee_message(bt('Bee for Backdrop CMS - Version ' . $current_version), 'success');
+}

--- a/includes/globals.inc
+++ b/includes/globals.inc
@@ -93,3 +93,6 @@ define('BEE_BOOTSTRAP_LANGUAGE', 7);
 
 // 9th phase: Backdrop is fully loaded; validate and fix input data.
 define('BEE_BOOTSTRAP_FULL', 8);
+
+// Current version of Bee
+define('BEE_VERSION', 'v1.0.0');

--- a/includes/miscellaneous.inc
+++ b/includes/miscellaneous.inc
@@ -93,7 +93,7 @@ function bee_initialize_console() {
 function bee_bootstrap($level) {
   global $_bee_backdrop_installed, $_bee_backdrop_root;
 
-  if (!$_bee_backdrop_installed && $level > BEE_BOOTSTRAP_PAGE_CACHE) {
+  if (!$_bee_backdrop_installed && $level > BEE_BOOTSTRAP_DATABASE) {
     return FALSE;
   }
 


### PR DESCRIPTION
Also changed the minimum boostrap so that the db could init enough to drop and re-add for Drush functionality compatibility. There is some residual from my version command in the other pull request as I am running a docker image based off my branch. It will be resolved by merging one or the other after review.