### PR TITLE
Fix the `--db-pass` option in help examples for the `install` command

### DIFF
--- a/commands/install.bee.inc
+++ b/commands/install.bee.inc
@@ -71,8 +71,8 @@ function install_bee_command() {
       'aliases' => array('si', 'site-install'),
       'examples' => array(
         'bee install' => bt('Install Backdrop in interactive mode, providing information when prompted.'),
-        'bee install --db-name=backdrop --db-user=admin --db-password=P@ssw0rd! --auto' => bt('Install Backdrop automatically using the provided database credentials, and default settings for everything else.'),
-        'bee install --db-name=backdrop --db-user=admin --db-password=P@ssw0rd! --db-host=db_server --username=Root --password=N0tS3cur3 --email=root@mydomain.com --site-name="My awesome site!"' => bt('Install Backdrop using the given options, and be prompted for the rest.'),
+        'bee install --db-name=backdrop --db-user=admin --db-pass=P@ssw0rd! --auto' => bt('Install Backdrop automatically using the provided database credentials, and default settings for everything else.'),
+        'bee install --db-name=backdrop --db-user=admin --db-pass=P@ssw0rd! --db-host=db_server --username=Root --password=N0tS3cur3 --email=root@mydomain.com --site-name="My awesome site!"' => bt('Install Backdrop using the given options, and be prompted for the rest.'),
       ),
     ),
   );


### PR DESCRIPTION
Hey @BWPanda and/or @yorkshire-pudding 👋🏼 ...I've noticed that this was missed when merging https://github.com/backdrop-contrib/bee/pull/183