### PR TITLE
Issue #195: Add support for --uri option.

### DIFF
--- a/includes/globals.inc
+++ b/includes/globals.inc
@@ -16,6 +16,9 @@ $_bee_global_options = array(
   'site' => array(
     'description' => bt("Specify the directory name or URL of the Backdrop site to use (as defined in 'sites.php'). If not set, will try to find the Backdrop site automatically based on the current directory."),
   ),
+  'uri' => array(
+    'description' => bt('Specify the base URL of your Backdrop site, such as https://example.com/backdrop.'),
+  ),
   'yes' => array(
     'description' => bt("Answer 'yes' to questions without prompting."),
     'short' => 'y',

--- a/includes/miscellaneous.inc
+++ b/includes/miscellaneous.inc
@@ -49,7 +49,20 @@ function bee_initialize_console() {
     chdir($_bee_backdrop_root);
     $_bee_backdrop_root = getcwd();
     define('BACKDROP_ROOT', $_bee_backdrop_root);
-    $_SERVER['HTTP_HOST'] = !empty($_bee_backdrop_site) ? $_bee_backdrop_site : basename($_bee_backdrop_root);
+
+    
+    if ($_bee_options['uri']) {
+      $uri_parts = parse_url($_bee_options['uri']);
+      $_SERVER['HTTP_HOST'] = $uri_parts['host'] . ($uri_parts['port'] ? ':' . $uri_parts['port'] : '');
+      $_SERVER['HTTPS'] = $uri_parts['scheme'] === 'https';
+      $GLOBALS['base_url'] = $_bee_options['uri'];
+    }
+    elseif ($_bee_backdrop_site) {
+      $_SERVER['HTTP_HOST'] = $_bee_backdrop_site;
+    }
+    else {
+      $_SERVER['HTTP_HOST'] = basename($_bee_backdrop_root);
+    }
 
     // Determine if Backdrop is installed or not.
     require_once $_bee_backdrop_root . '/core/includes/bootstrap.inc';


### PR DESCRIPTION
Initial work to support --uri option: https://github.com/backdrop-contrib/bee/issues/195

To test:

* Do not specify a $base_url in settings.php
* Use a command that generates a URL, such as `uli`: `bee --uri=https://example.com uli`
* The output should use the specified URI as the base URL, e.g. https://example.com/user/reset/1/1659390793/[hash]/login

Using https vs. http, sub-directories, and port numbers should all work.