### PR TITLE
Fixes #215 php8.1 assert function null instead of string

### DIFF
--- a/tests/backdrop/BeeCoreTest.php
+++ b/tests/backdrop/BeeCoreTest.php
@@ -23,7 +23,7 @@ class BeeCoreTest extends TestCase {
   public function test_unknown_command_triggers_an_error() {
     $command = 'spoon';
     $output = shell_exec("bee $command");
-    $this->assertStringContainsString("There is no '$command' command.", $output);
+    $this->assertStringContainsString("There is no '$command' command.", (string) $output);
   }
 
   /**
@@ -32,7 +32,7 @@ class BeeCoreTest extends TestCase {
   public function test_missing_required_argument_triggers_an_error() {
     // `config-get` has a required argument: 'file'.
     $output = shell_exec('bee config-get');
-    $this->assertStringContainsString("Argument 'file' is required.", $output);
+    $this->assertStringContainsString("Argument 'file' is required.", (string) $output);
   }
 
   /**
@@ -53,10 +53,10 @@ class BeeCoreTest extends TestCase {
    */
   public function test_root_global_option_works() {
     $output_no_root = shell_exec('cd ../ && bee status');
-    $this->assertStringContainsString('No Backdrop installation found.', $output_no_root);
+    $this->assertStringContainsString('No Backdrop installation found.', (string) $output_no_root);
 
     $output_root = shell_exec('cd ../ && bee --root=backdrop status');
-    $this->assertStringNotContainsString('No Backdrop installation found.', $output_root);
+    $this->assertStringNotContainsString('No Backdrop installation found.', (string) $output_root);
   }
 
   /**
@@ -68,14 +68,14 @@ class BeeCoreTest extends TestCase {
     $value = 'bar';
 
     $output_yes = shell_exec("bee config-set --yes $file $option $value");
-    $this->assertStringContainsString("The '$file' config file doesn't exist.", $output_yes);
-    $this->assertStringContainsString("'$option' was set to '$value' in '$file'.", $output_yes);
+    $this->assertStringContainsString("The '$file' config file doesn't exist.", (string) $output_yes);
+    $this->assertStringContainsString("'$option' was set to '$value' in '$file'.", (string) $output_yes);
 
     $file2 = $file . '2';
 
     $output_y = shell_exec("bee config-set --y $file2 $option $value");
-    $this->assertStringContainsString("The '$file2' config file doesn't exist.", $output_y);
-    $this->assertStringContainsString("'$option' was set to '$value' in '$file2'.", $output_y);
+    $this->assertStringContainsString("The '$file2' config file doesn't exist.", (string) $output_y);
+    $this->assertStringContainsString("'$option' was set to '$value' in '$file2'.", (string) $output_y);
 
     // Cleanup config files.
     // Using `find` allows us to find and delete the necessary files without
@@ -89,10 +89,10 @@ class BeeCoreTest extends TestCase {
    */
   public function test_debug_global_option_works() {
     $output_debug = shell_exec("bee status --debug");
-    $this->assertStringContainsString("'Debug' mode enabled.", $output_debug);
+    $this->assertStringContainsString("'Debug' mode enabled.", (string) $output_debug);
 
     $output_d = shell_exec("bee status --d");
-    $this->assertStringContainsString("'Debug' mode enabled.", $output_d);
+    $this->assertStringContainsString("'Debug' mode enabled.", (string) $output_d);
   }
 
 }

--- a/tests/backdrop/CacheCommandsTest.php
+++ b/tests/backdrop/CacheCommandsTest.php
@@ -13,10 +13,10 @@ class CacheCommandsTest extends TestCase {
    */
   public function test_cache_clear_command_works() {
     $output_all = shell_exec('bee cache-clear all');
-    $this->assertStringContainsString('Cache(s) cleared: All', $output_all);
+    $this->assertStringContainsString('Cache(s) cleared: All', (string) $output_all);
 
     $output_menu = shell_exec('bee cache-clear menu');
-    $this->assertStringContainsString('Cache(s) cleared: Menu', $output_menu);
+    $this->assertStringContainsString('Cache(s) cleared: Menu', (string) $output_menu);
   }
 
 }

--- a/tests/backdrop/ConfigCommandsTest.php
+++ b/tests/backdrop/ConfigCommandsTest.php
@@ -13,11 +13,11 @@ class ConfigCommandsTest extends TestCase {
    */
   public function test_config_get_command_works() {
     $output_all = shell_exec('bee config-get system.core');
-    $this->assertStringContainsString("'admin_theme' => 'seven',", $output_all);
-    $this->assertStringContainsString("'site_frontpage' => 'home',", $output_all);
+    $this->assertStringContainsString("'admin_theme' => 'seven',", (string) $output_all);
+    $this->assertStringContainsString("'site_frontpage' => 'home',", (string) $output_all);
 
     $output_theme = shell_exec('bee config-get system.core theme_default');
-    $this->assertStringContainsString("'basis'", $output_theme);
+    $this->assertStringContainsString("'basis'", (string) $output_theme);
   }
 
   /**
@@ -34,19 +34,19 @@ class ConfigCommandsTest extends TestCase {
 
     // Make sure the current homepage is 'home'.
     $output = shell_exec("bee config-get $file $option");
-    $this->assertStringContainsString($value, $output);
+    $this->assertStringContainsString((string) $value, (string) $output);
 
     // Set a new value for the homepage.
     $output = shell_exec("bee config-set $file $option $new");
-    $this->assertStringContainsString("'$option' was set to '$new' in '$file'.", $output);
+    $this->assertStringContainsString("'$option' was set to '$new' in '$file'.", (string) $output);
 
     // Make sure the new homepage is 'about'.
     $output = shell_exec("bee config-get $file $option");
-    $this->assertStringContainsString($new, $output);
+    $this->assertStringContainsString((string) $new, (string) $output);
 
     // Make sure 'empty' values can be set.
     $output = shell_exec("bee config-set $file $option2 $new2");
-    $this->assertStringContainsString("'$option2' was set to '$new2' in '$file'.", $output);
+    $this->assertStringContainsString("'$option2' was set to '$new2' in '$file'.", (string) $output);
 
     // Reset config values for future tests.
     exec("bee config-set $file $option $value");
@@ -63,7 +63,7 @@ class ConfigCommandsTest extends TestCase {
     $this->assertNotEquals(count($active), count($staging_before));
 
     $output = shell_exec('bee config-export');
-    $this->assertStringContainsString('Config was exported to', $output);
+    $this->assertStringContainsString('Config was exported to', (string) $output);
 
     // Number of files in active and staging should be the same.
     exec('find files/config_*/staging -type f', $staging_after);
@@ -82,8 +82,8 @@ class ConfigCommandsTest extends TestCase {
     $this->assertFileExists($file);
 
     $output = shell_exec('bee config-import -y');
-    $this->assertStringContainsString('Config was imported to', $output);
-    $this->assertStringContainsString('1 file was synced.', $output);
+    $this->assertStringContainsString('Config was imported to', (string) $output);
+    $this->assertStringContainsString('1 file was synced.', (string) $output);
 
     // Verify config file doesn't exist in active.
     $this->assertFileNotExists($file);

--- a/tests/backdrop/CronCommandsTest.php
+++ b/tests/backdrop/CronCommandsTest.php
@@ -13,7 +13,7 @@ class CronCommandsTest extends TestCase {
    */
   public function test_cron_command_works() {
     $output = shell_exec('bee cron');
-    $this->assertStringContainsString('Cron ran successfully.', $output);
+    $this->assertStringContainsString('Cron ran successfully.', (string) $output);
   }
 
 }

--- a/tests/backdrop/DBCommandsTest.php
+++ b/tests/backdrop/DBCommandsTest.php
@@ -13,7 +13,7 @@ class DBCommandsTest extends TestCase {
    */
   public function test_db_export_command_works() {
     $output = shell_exec('bee db-export database.sql');
-    $this->assertStringContainsString("The 'backdrop' database was exported to '/app/backdrop/database.sql.gz'.", $output);
+    $this->assertStringContainsString("The 'backdrop' database was exported to '/app/backdrop/database.sql.gz'.", (string) $output);
     $this->assertTrue(file_exists('/app/backdrop/database.sql.gz'));
   }
 
@@ -22,7 +22,7 @@ class DBCommandsTest extends TestCase {
    */
   public function test_db_import_command_works() {
     $output = shell_exec('bee db-import database.sql.gz');
-    $this->assertStringContainsString("'database.sql.gz' was imported into the 'backdrop' database.", $output);
+    $this->assertStringContainsString("'database.sql.gz' was imported into the 'backdrop' database.", (string) $output);
 
     // Remove DB export for future tests.
     exec('rm /app/backdrop/database.sql.gz');

--- a/tests/backdrop/DBLogCommandsTest.php
+++ b/tests/backdrop/DBLogCommandsTest.php
@@ -13,23 +13,23 @@ class DBLogCommandsTest extends TestCase {
    */
   public function test_log_command_works() {
     $output_all = shell_exec('bee log');
-    $this->assertStringContainsString(' | Date', $output_all);
-    $this->assertStringContainsString(' | Message', $output_all);
+    $this->assertStringContainsString(' | Date', (string) $output_all);
+    $this->assertStringContainsString(' | Message', (string) $output_all);
 
     $output_one = shell_exec('bee log 1');
-    $this->assertStringContainsString('dblog module installed.', $output_one);
+    $this->assertStringContainsString('dblog module installed.', (string) $output_one);
 
     exec('bee log --count=2', $output_count);
     // The header and trailing newline add 2 extra rows to the output.
     $this->assertEquals(4, count($output_count));
 
     $output_severity = shell_exec('bee log --severity=info');
-    $this->assertStringContainsString(' | Info', $output_severity);
-    $this->assertStringNotContainsString(' | Notice', $output_severity);
+    $this->assertStringContainsString(' | Info', (string) $output_severity);
+    $this->assertStringNotContainsString(' | Notice', (string) $output_severity);
 
     $output_type = shell_exec('bee log --type=cron');
-    $this->assertStringContainsString(' | cron', $output_type);
-    $this->assertStringNotContainsString(' | system', $output_type);
+    $this->assertStringContainsString(' | cron', (string) $output_type);
+    $this->assertStringNotContainsString(' | system', (string) $output_type);
   }
 
 }

--- a/tests/backdrop/DownloadCommandsTest.php
+++ b/tests/backdrop/DownloadCommandsTest.php
@@ -14,14 +14,14 @@ class DownloadCommandsTest extends TestCase {
   public function test_download_command_works() {
     // Single module.
     $output_single = shell_exec('bee download --hide-progress simplify');
-    $this->assertStringContainsString("'simplify' was downloaded into '/app/backdrop/modules/simplify'.", $output_single);
+    $this->assertStringContainsString("'simplify' was downloaded into '/app/backdrop/modules/simplify'.", (string) $output_single);
     $this->assertTrue(file_exists('/app/backdrop/modules/simplify/simplify.info'));
 
     // Multiple projects (theme and layout).
     $output_multiple = shell_exec('bee download --hide-progress lumi bamboo');
-    $this->assertStringContainsString("'lumi' was downloaded into '/app/backdrop/themes/lumi'.", $output_multiple);
+    $this->assertStringContainsString("'lumi' was downloaded into '/app/backdrop/themes/lumi'.", (string) $output_multiple);
     $this->assertTrue(file_exists('/app/backdrop/themes/lumi/lumi.info'));
-    $this->assertStringContainsString("'bamboo' was downloaded into '/app/backdrop/layouts/bamboo'.", $output_multiple);
+    $this->assertStringContainsString("'bamboo' was downloaded into '/app/backdrop/layouts/bamboo'.", (string) $output_multiple);
     $this->assertTrue(file_exists('/app/backdrop/layouts/bamboo/bamboo.info'));
 
     // Cleanup downloads.
@@ -34,12 +34,12 @@ class DownloadCommandsTest extends TestCase {
   public function test_download_core_command_works() {
     // Download to current directory.
     $output_current = shell_exec('mkdir /app/current && cd /app/current && bee download-core --hide-progress');
-    $this->assertStringContainsString("Backdrop was downloaded into '/app/current'.", $output_current);
+    $this->assertStringContainsString("Backdrop was downloaded into '/app/current'.", (string) $output_current);
     $this->assertTrue(file_exists('/app/current/index.php'));
 
     // Download to specified directory.
     $output_directory = shell_exec('bee download-core --hide-progress /app/directory');
-    $this->assertStringContainsString("Backdrop was downloaded into '/app/directory'.", $output_directory);
+    $this->assertStringContainsString("Backdrop was downloaded into '/app/directory'.", (string) $output_directory);
     $this->assertTrue(file_exists('/app/directory/index.php'));
 
     // Cleanup downloads.

--- a/tests/backdrop/HelpCommandsTest.php
+++ b/tests/backdrop/HelpCommandsTest.php
@@ -14,14 +14,14 @@ class HelpCommandsTest extends TestCase {
   public function test_help_command_works() {
     // Display help for `bee` in general.
     $output_all = shell_exec('bee help');
-    $this->assertStringContainsString('Usage: bee [global-options] <command> [options] [arguments]', $output_all);
-    $this->assertStringContainsString("Answer 'yes' to questions without prompting.", $output_all);
-    $this->assertStringContainsString('Clear a specific cache, or all Backdrop caches.', $output_all);
+    $this->assertStringContainsString('Usage: bee [global-options] <command> [options] [arguments]', (string) $output_all);
+    $this->assertStringContainsString("Answer 'yes' to questions without prompting.", (string) $output_all);
+    $this->assertStringContainsString('Clear a specific cache, or all Backdrop caches.', (string) $output_all);
 
     // Display help for the `help` command.
     $output_help = shell_exec('bee help help');
-    $this->assertStringContainsString("Provide help and examples for 'bee' and its commands.", $output_help);
-    $this->assertStringContainsString('The command to display help for.', $output_help);
+    $this->assertStringContainsString("Provide help and examples for 'bee' and its commands.", (string) $output_help);
+    $this->assertStringContainsString('The command to display help for.', (string) $output_help);
   }
 
 }

--- a/tests/backdrop/PHPCommandsTest.php
+++ b/tests/backdrop/PHPCommandsTest.php
@@ -14,16 +14,16 @@ class PHPCommandsTest extends TestCase {
   public function test_eval_command_works() {
     // Test a simple command.
     $output_simple = shell_exec('bee eval \'echo "foo" . "bar";\'');
-    $this->assertStringContainsString('foobar', $output_simple);
+    $this->assertStringContainsString('foobar', (string) $output_simple);
 
     // Test that the terminal semicolon is optional.
     $output_semicolon = shell_exec('bee eval \'echo "Hello world."\'');
-    $this->assertStringContainsString('Hello world.', $output_semicolon);
+    $this->assertStringContainsString('Hello world.', (string) $output_semicolon);
 
     // Test that calling a Backdrop function works.
     exec('bee eval \'config_set("test.settings", "value", "foobar")\'');
     $output_backdrop = shell_exec('bee eval \'echo config_get("test.settings", "value")\'');
-    $this->assertStringContainsString('foobar', $output_backdrop);
+    $this->assertStringContainsString('foobar', (string) $output_backdrop);
     
     // Cleanup test config file.
     exec('bee eval \'config("test.settings")->delete();\'');

--- a/tests/backdrop/ProjectsCommandsTest.php
+++ b/tests/backdrop/ProjectsCommandsTest.php
@@ -14,20 +14,20 @@ class ProjectsCommandsTest extends TestCase {
   public function test_projects_command_works() {
     // All projects.
     $output_all = shell_exec('bee projects');
-    $this->assertRegExp('/| admin_bar +| Administration Bar +| module +| Enabled +|/', $output_all);
-    $this->assertRegExp('/| bartik +| Bartik +| theme +| Disabled +|/', $output_all);
-    $this->assertRegExp('/| moscone +| Moscone +| layout +| Enabled +|/', $output_all);
+    $this->assertRegExp('/| admin_bar +| Administration Bar +| module +| Enabled +|/', (string) $output_all);
+    $this->assertRegExp('/| bartik +| Bartik +| theme +| Disabled +|/', (string) $output_all);
+    $this->assertRegExp('/| moscone +| Moscone +| layout +| Enabled +|/', (string) $output_all);
 
     // Specific project.
     $output_project = shell_exec('bee projects contact');
-    $this->assertRegExp('/Name +Contact/', $output_project);
-    $this->assertRegExp('/Description +Enables the use of both personal and site-wide contact forms./', $output_project);
+    $this->assertRegExp('/Name +Contact/', (string) $output_project);
+    $this->assertRegExp('/Description +Enables the use of both personal and site-wide contact forms./', (string) $output_project);
 
     // Just modules.
     $output_modules = shell_exec('bee projects --type=module');
-    $this->assertRegExp('/| taxonomy +| Taxonomy +| module +| Enabled +|/', $output_modules);
-    $this->assertStringNotContainsString(' | theme ', $output_modules);
-    $this->assertStringNotContainsString(' | layout ', $output_modules);
+    $this->assertRegExp('/| taxonomy +| Taxonomy +| module +| Enabled +|/', (string) $output_modules);
+    $this->assertStringNotContainsString(' | theme ', (string) $output_modules);
+    $this->assertStringNotContainsString(' | layout ', (string) $output_modules);
   }
 
   /**
@@ -35,11 +35,11 @@ class ProjectsCommandsTest extends TestCase {
    */
   public function test_enable_command_works() {
     $output_single = shell_exec('bee enable contact');
-    $this->assertStringContainsString("The 'Contact' module was enabled.", $output_single);
+    $this->assertStringContainsString("The 'Contact' module was enabled.", (string) $output_single);
 
     $output_multiple = shell_exec('bee enable book bartik');
-    $this->assertStringContainsString("The 'Book' module was enabled.", $output_multiple);
-    $this->assertStringContainsString("The 'Bartik' theme was enabled.", $output_multiple);
+    $this->assertStringContainsString("The 'Book' module was enabled.", (string) $output_multiple);
+    $this->assertStringContainsString("The 'Bartik' theme was enabled.", (string) $output_multiple);
   }
 
   /**
@@ -47,11 +47,11 @@ class ProjectsCommandsTest extends TestCase {
    */
   public function test_disable_command_works() {
     $output_single = shell_exec('bee disable contact');
-    $this->assertStringContainsString("The 'Contact' module was disabled.", $output_single);
+    $this->assertStringContainsString("The 'Contact' module was disabled.", (string) $output_single);
 
     $output_multiple = shell_exec('bee disable book bartik');
-    $this->assertStringContainsString("The 'Book' module was disabled.", $output_multiple);
-    $this->assertStringContainsString("The 'Bartik' theme was disabled.", $output_multiple);
+    $this->assertStringContainsString("The 'Book' module was disabled.", (string) $output_multiple);
+    $this->assertStringContainsString("The 'Bartik' theme was disabled.", (string) $output_multiple);
   }
 
   /**
@@ -59,8 +59,8 @@ class ProjectsCommandsTest extends TestCase {
    */
   public function test_uninstall_command_works() {
     $output = shell_exec('bee uninstall contact book');
-    $this->assertStringContainsString("The 'Contact' module was uninstalled.", $output);
-    $this->assertStringContainsString("The 'Book' module was uninstalled.", $output);
+    $this->assertStringContainsString("The 'Contact' module was uninstalled.", (string) $output);
+    $this->assertStringContainsString("The 'Book' module was uninstalled.", (string) $output);
   }
 
   /**
@@ -68,7 +68,7 @@ class ProjectsCommandsTest extends TestCase {
    */
   public function test_theme_default_command_works() {
     $output = shell_exec('bee theme-default bartik');
-    $this->assertStringContainsString("'Bartik' was set as the default theme.", $output);
+    $this->assertStringContainsString("'Bartik' was set as the default theme.", (string) $output);
 
     // Reset theme.
     exec('bee theme-default basis');
@@ -80,7 +80,7 @@ class ProjectsCommandsTest extends TestCase {
    */
   public function test_theme_admin_command_works() {
     $output = shell_exec('bee theme-admin basis');
-    $this->assertStringContainsString("Basis' was set as the admin theme.", $output);
+    $this->assertStringContainsString("Basis' was set as the admin theme.", (string) $output);
 
     // Reset theme.
     exec('bee theme-admin seven');

--- a/tests/backdrop/UpdateCommandsTest.php
+++ b/tests/backdrop/UpdateCommandsTest.php
@@ -19,7 +19,7 @@ class UpdateCommandsTest extends TestCase {
 
     // Make sure there are no database updates.
     $output_clean = shell_exec('bee update-db');
-    $this->assertStringContainsString('There are no pending database updates.', $output_clean);
+    $this->assertStringContainsString('There are no pending database updates.', (string) $output_clean);
 
     // Update Devel to a newer version.
     exec('cd modules && rm -rf devel && wget -q https://github.com/backdrop-contrib/devel/releases/download/1.x-1.6.0/devel.zip');
@@ -27,9 +27,9 @@ class UpdateCommandsTest extends TestCase {
 
     // Perform database updates.
     $output_updates = shell_exec('bee update-db --y');
-    $this->assertStringContainsString('Remove option for Krumo skin.', $output_updates);
-    $this->assertStringContainsString('Would you like to apply all pending updates?', $output_updates);
-    $this->assertStringContainsString('All pending updates applied.', $output_updates);
+    $this->assertStringContainsString('Remove option for Krumo skin.', (string) $output_updates);
+    $this->assertStringContainsString('Would you like to apply all pending updates?', (string) $output_updates);
+    $this->assertStringContainsString('All pending updates applied.', (string) $output_updates);
 
     // Cleanup Devel.
     exec('bee disable --y devel');

--- a/tests/backdrop/UserCommandsTest.php
+++ b/tests/backdrop/UserCommandsTest.php
@@ -13,7 +13,7 @@ class UserCommandsTest extends TestCase {
    */
   public function test_users_command_works() {
     $output = shell_exec('bee users');
-    $this->assertRegExp('/| 1 +| admin +| admin@example.com +|/', $output);
+    $this->assertRegExp('/| 1 +| admin +| admin@example.com +|/', (string) $output);
   }
 
   /**
@@ -21,12 +21,12 @@ class UserCommandsTest extends TestCase {
    */
   public function test_user_password_command_works() {
     $output_password = shell_exec('bee user-password admin 123456');
-    $this->assertStringContainsString("The password for 'admin' has been reset.", $output_password);
-    $this->assertStringNotContainsString('The new password is:', $output_password);
+    $this->assertStringContainsString("The password for 'admin' has been reset.", (string) $output_password);
+    $this->assertStringNotContainsString('The new password is:', (string) $output_password);
 
     $output_random = shell_exec('bee user-password admin');
-    $this->assertStringContainsString("The password for 'admin' has been reset.", $output_random);
-    $this->assertStringContainsString('The new password is:', $output_random);
+    $this->assertStringContainsString("The password for 'admin' has been reset.", (string) $output_random);
+    $this->assertStringContainsString('The new password is:', (string) $output_random);
   }
 
   /**
@@ -34,13 +34,13 @@ class UserCommandsTest extends TestCase {
    */
   public function test_user_login_command_works() {
     $output = shell_exec('bee user-login admin');
-    $this->assertStringContainsString("Use the following link to login as 'admin':", $output);
-    $this->assertStringContainsString('/user/reset/1/', $output);
+    $this->assertStringContainsString("Use the following link to login as 'admin':", (string) $output);
+    $this->assertStringContainsString('/user/reset/1/', (string) $output);
 
     // Test that leaving the username argument blank loads User 1.
     $output = shell_exec('bee user-login');
-    $this->assertStringContainsString("Use the following link to login as 'admin':", $output);
-    $this->assertStringContainsString('/user/reset/1/', $output);
+    $this->assertStringContainsString("Use the following link to login as 'admin':", (string) $output);
+    $this->assertStringContainsString('/user/reset/1/', (string) $output);
   }
 
 }

--- a/tests/multisite/MultisiteDownloadCommandsTest.php
+++ b/tests/multisite/MultisiteDownloadCommandsTest.php
@@ -14,17 +14,17 @@ class MultisiteDownloadCommandsTest extends TestCase {
   public function test_download_command_works() {
     // Root directory, no site specified.
     $output_root = shell_exec('bee download --hide-progress simplify');
-    $this->assertStringContainsString("'simplify' was downloaded into '/app/multisite/modules/simplify'.", $output_root);
+    $this->assertStringContainsString("'simplify' was downloaded into '/app/multisite/modules/simplify'.", (string) $output_root);
     $this->assertTrue(file_exists('/app/multisite/modules/simplify/simplify.info'));
 
     // Root directory, site specified.
     $output_root_site = shell_exec('bee download --site=multi_one --hide-progress lumi');
-    $this->assertStringContainsString("'lumi' was downloaded into '/app/multisite/sites/multi_one/themes/lumi'.", $output_root_site);
+    $this->assertStringContainsString("'lumi' was downloaded into '/app/multisite/sites/multi_one/themes/lumi'.", (string) $output_root_site);
     $this->assertTrue(file_exists('/app/multisite/sites/multi_one/themes/lumi/lumi.info'));
 
     // Site directory.
     $output_site = shell_exec('cd sites/multi_two && bee download --hide-progress bamboo');
-    $this->assertStringContainsString("'bamboo' was downloaded into '/app/multisite/sites/multi_two/layouts/bamboo'.", $output_site);
+    $this->assertStringContainsString("'bamboo' was downloaded into '/app/multisite/sites/multi_two/layouts/bamboo'.", (string) $output_site);
     $this->assertTrue(file_exists('/app/multisite/sites/multi_two/layouts/bamboo/bamboo.info'));
 
     // Cleanup downloads.

--- a/tests/multisite/MultisiteInstallCommandsTest.php
+++ b/tests/multisite/MultisiteInstallCommandsTest.php
@@ -14,20 +14,20 @@ class MultisiteInstallCommandsTest extends TestCase {
   public function test_install_command_works() {
     // Check site status before install.
     $output_before = shell_exec('bee status --site=install_test');
-    $this->assertRegExp('/Site type +Multisite/', $output_before);
-    $this->assertRegExp('/Site directory +install_test/', $output_before);
-    $this->assertStringNotContainsString('Database', $output_before);
+    $this->assertRegExp('/Site type +Multisite/', (string) $output_before);
+    $this->assertRegExp('/Site directory +install_test/', (string) $output_before);
+    $this->assertStringNotContainsString('Database', (string) $output_before);
 
     // Install the site.
     $output_install = shell_exec('bee install --site=install_test --db-name=install_test --db-user=backdrop --db-pass=backdrop --db-host=database --auto');
-    $this->assertStringContainsString('Backdrop installed successfully.', $output_install);
+    $this->assertStringContainsString('Backdrop installed successfully.', (string) $output_install);
 
     // Check site status after install.
     $output_after = shell_exec('bee status --site=install_test');
-    $this->assertRegExp('/Site type +Multisite/', $output_after);
-    $this->assertRegExp('/Site directory +install_test/', $output_after);
-    $this->assertRegExp('/Database name +install_test/', $output_after);
-    $this->assertRegExp('/Database host +database/', $output_after);
+    $this->assertRegExp('/Site type +Multisite/', (string) $output_after);
+    $this->assertRegExp('/Site directory +install_test/', (string) $output_after);
+    $this->assertRegExp('/Database name +install_test/', (string) $output_after);
+    $this->assertRegExp('/Database host +database/', (string) $output_after);
 
     // Cleanup the install.
     exec('rm -r sites/install_test/files');

--- a/tests/multisite/MultisiteTest.php
+++ b/tests/multisite/MultisiteTest.php
@@ -17,16 +17,16 @@ class MultisiteTest extends TestCase {
    */
   public function test_site_global_option_works() {
     $output_no_site = shell_exec('bee status');
-    $this->assertRegExp('/Site type +Multisite/', $output_no_site);
-    $this->assertNotRegExp('/Site directory +multisite/', $output_no_site);
+    $this->assertRegExp('/Site type +Multisite/', (string) $output_no_site);
+    $this->assertNotRegExp('/Site directory +multisite/', (string) $output_no_site);
 
     $output_site_dir = shell_exec('bee --site=multi_one status');
-    $this->assertRegExp('/Site type +Multisite/', $output_site_dir);
-    $this->assertRegExp('/Site directory +multi_one/', $output_site_dir);
+    $this->assertRegExp('/Site type +Multisite/', (string) $output_site_dir);
+    $this->assertRegExp('/Site directory +multi_one/', (string) $output_site_dir);
 
     $output_site_url = shell_exec('bee --site=multi-2.lndo.site status');
-    $this->assertRegExp('/Site type +Multisite/', $output_site_url);
-    $this->assertRegExp('/Site directory +multi_two/', $output_site_url);
+    $this->assertRegExp('/Site type +Multisite/', (string) $output_site_url);
+    $this->assertRegExp('/Site directory +multi_two/', (string) $output_site_url);
   }
 
 }


### PR DESCRIPTION
Fixes #215 
Added type casting to all `assertRegExp`, `assertNotRegExp`, `assertStringNotContainsString`,`assertStringContainsString` functions as it is when there is an error that these are most likely to include `null` values.

tested on both PHP 7.4 and 8.1 and all tests are passing