### PR TITLE
Fixes #214: Suppress error: "Undefined index q" when fast_404 enabled

### DIFF
--- a/includes/miscellaneous.inc
+++ b/includes/miscellaneous.inc
@@ -19,6 +19,7 @@ function bee_initialize_server() {
   $_SERVER['SCRIPT_NAME'] = '/index.php';
   $_SERVER['PHP_SELF'] = '/index.php';
   $_SERVER['HTTP_USER_AGENT'] = 'Bee';
+  $_GET['q'] = 'node';
 }
 
 /**


### PR DESCRIPTION
Fixes #214 Error "Undefined Index" when fast_404() is enabled in settings.php