### PR TITLE
Add support for command level short form options (#286)

### DIFF
--- a/commands/download.bee.inc
+++ b/commands/download.bee.inc
@@ -20,9 +20,11 @@ function download_bee_command() {
       'options' => array(
         'hide-progress' => array(
           'description' => bt('Hide the download progress bar.'),
+          'short' => 'h',
         ),
         'allow-multisite-copy' => array(
           'description' => bt('Override the check that would prevent the project being downloaded to a multisite site if the project exists in the shared project directory.'),
+          'short' => 'f',
         ),
       ),
       'aliases' => array('dl', 'pm-download'),
@@ -44,6 +46,7 @@ function download_bee_command() {
       'options' => array(
         'hide-progress' => array(
           'description' => bt('Hide the download progress bar.'),
+          'short' => 'h',
         ),
       ),
       'aliases' => array('dl-core'),

--- a/commands/help.bee.inc
+++ b/commands/help.bee.inc
@@ -261,7 +261,9 @@ function help_bee_command_help(array $descriptor) {
     $rows = array();
     foreach ($descriptor['options'] as $option_name => $option) {
       $value = !empty($option['value']) ? '=' . strtoupper($option['value']) : '';
-
+      if (isset($option['short'])) {
+        $option_name .= ', -' . $option['short'];
+      }
       $rows[] = array(
         array(
           'value' => '--' . $option_name . $value,

--- a/commands/install.bee.inc
+++ b/commands/install.bee.inc
@@ -64,9 +64,11 @@ function install_bee_command() {
         ),
         'no-clean-urls' => array(
           'description' => bt('Disable clean URLs.'),
+          'short' >= 'n',
         ),
         'auto' => array(
           'description' => bt('Perform an automatic (i.e. non-interactive) installation. Any options not explicitly provided to the command will use default values, except the database connection string which will always prompt when not provided.'),
+          'short' >= 'a',
         ),
       ),
       'aliases' => array('si', 'site-install'),

--- a/commands/projects.bee.inc
+++ b/commands/projects.bee.inc
@@ -42,6 +42,7 @@ function projects_bee_command() {
       'options' => array(
         'no-dependency-checking' => array(
           'description' => bt('Disable dependency-checking and enable module(s) regardless. This could cause problems if there are missing dependencies. Use with caution.'),
+          'short' >= 'n',
         ),
       ),
       'aliases' => array('en', 'pm-enable'),
@@ -63,6 +64,7 @@ function projects_bee_command() {
       'options' => array(
         'no-dependency-checking' => array(
           'description' => bt('Disable dependency-checking and disable module(s) regardless. This could cause problems if there are other enabled modules that depend on this one. Use with caution.'),
+          'short' >= 'n',
         ),
       ),
       'aliases' => array('dis', 'pm-disable'),
@@ -84,6 +86,7 @@ function projects_bee_command() {
       'options' => array(
         'no-dependency-checking' => array(
           'description' => bt('Disable dependency-checking and uninstall module(s) regardless. This could cause problems if there are other installed modules that depend on this one. Use with caution.'),
+          'short' >= 'n',
         ),
       ),
       'aliases' => array('pmu', 'pm-uninstall'),

--- a/commands/status.bee.inc
+++ b/commands/status.bee.inc
@@ -16,6 +16,7 @@ function status_bee_command() {
       'options' => array(
         'show-password' => array(
           'description' => bt('Show the database password.'),
+          'short' => 'p',
         ),
       ),
       'aliases' => array('st', 'info', 'core-status'),
@@ -81,9 +82,10 @@ function status_bee_callback($arguments, $options) {
           array('value' => bt('Database username')),
           array('value' => rawurldecode($info['username'])),
         );
+        $status_show_password = (isset($options['show-password']) || isset($options['p']));
         $rows[] = array(
           array('value' => bt('Database password')),
-          array('value' => isset($options['show-password']) ? rawurldecode($info['password']) : '**********'),
+          array('value' => $status_show_password ? rawurldecode($info['password']) : '**********'),
         );
         $rows[] = array(
           array('value' => bt('Database host')),

--- a/includes/command.inc
+++ b/includes/command.inc
@@ -282,8 +282,15 @@ function bee_validate_command(array $descriptor) {
   if (isset($descriptor['options'])) {
     // Remove any provided options that aren't used by the command.
     foreach ($_bee_options as $name => $value) {
+      // Check for long form command options.
       if (!isset($descriptor['options'][$name])) {
-        unset($_bee_options[$name]);
+        // Check for short form command options.
+        foreach ($descriptor['options'] as $command_option) {
+          if (!isset($command_option['short']) || $command_option['short'] != $name) {
+            // Remove any that don't match either long or short form options.
+            unset($_bee_options[$name]);
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
Tests have passed locally. #287 is still causing problems on workflow testing. PHPCS is fine.

* Add support for command level short form options Support short form options in commands and status command.

* Add other short options as suggested.