### PR TITLE
Issue #299 leave shared version when using multisite

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -34,7 +34,7 @@ services:
   database:
     healthcheck: mysql --defaults-extra-file=/app/.lando/mysql.cnf --silent --execute "SHOW DATABASES;"
   multisite:
-    type: php:8.2
+    type: php:8.3
     webroot: multisite
 events:
   pre-rebuild:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project follows the
 which is based on the major version of Backdrop CMS with a semantic version
 system for each contributed module, theme and layout.
 
-## [Unreleased] - 2024-09-06
+## [Unreleased] - 2024-09-07
+## [1.x-1.1.0] - 2024-09-07
 
 ### Added
 - A new function to check whether or not an executable exists in the system.
@@ -115,7 +116,8 @@ filenames) are included in table output.
 ### Changed
 - Changed from `b` to `bee`
 
-[Unreleased]: https://github.com/backdrop-contrib/bee/compare/1.x-1.0.2...HEAD
+[Unreleased]: https://github.com/backdrop-contrib/bee/compare/1.x-1.1.0...HEAD
+[1.x-1.1.0]: https://github.com/backdrop-contrib/bee/compare/1.x-1.0.2...1.x-1.1.0
 [1.x-1.0.2]: https://github.com/backdrop-contrib/bee/compare/1.x-1.0.1...1.x-1.0.2
 [1.x-1.0.1]: https://github.com/backdrop-contrib/bee/compare/1.x-1.0.0-beta...1.x-1.0.1
 [1.x-1.0.0-beta]: https://github.com/backdrop-contrib/bee/compare/v0.0.0...1.x-1.0.0-beta

--- a/commands/download.bee.inc
+++ b/commands/download.bee.inc
@@ -221,26 +221,13 @@ function download_bee_callback($arguments, $options) {
         )), 'error');
         return;
       }
-      else {
-        // Add an 's' to the end of the type name.
-        $type_folder = $info['type'] . 's';
-      }
 
-      // Get the directory to download the project into.
-      if (!empty($_bee_backdrop_site)) {
-        $destination = "$_bee_backdrop_root/sites/$_bee_backdrop_site/" . $type_folder;
-      }
-      elseif (!empty($_bee_backdrop_root)) {
-        $destination = "$_bee_backdrop_root/" . $type_folder;
-      }
-      else {
+      $destination = download_get_project_destination($project, $info['type']);
+      if (empty($destination)) {
         bee_message(bt("The download destination could not be determined. Re-run the command from within a Backdrop installation, or set the global '--root'/'--site' options."), 'error');
         return;
       }
-      if (file_exists("$destination/contrib")) {
-        $destination .= '/contrib';
-      }
-      $destination .= "/$project";
+
       // Check if the project exists within the site file system.
       $project_existing_location = download_bee_check_project_exists($project, $info['type']);
       $project_allow_multisite_copy = download_bee_check_multisite_copy($allow_multisite_copy, $project_existing_location);
@@ -268,6 +255,36 @@ function download_bee_callback($arguments, $options) {
     }
     $project_count++;
   }
+}
+
+/**
+ * A function to format the directory path of a project.
+ *
+ * @param string $project
+ *   The name of the project.
+ * @param string $type
+ *   The project type of the project.
+ * @return string The location where the project will be downloaded.
+ */
+function download_get_project_destination($project, $type) {
+  global $_bee_backdrop_root, $_bee_backdrop_site;
+
+  if (!empty($_bee_backdrop_site)) {
+    $destination = "$_bee_backdrop_root/sites/$_bee_backdrop_site/" . $type . 's';
+  }
+  elseif (!empty($_bee_backdrop_root)) {
+    $destination = "$_bee_backdrop_root/" . $type . 's';
+  }
+  else {
+    return '';
+  }
+
+  if (file_exists("$destination/contrib")) {
+    $destination .= '/contrib';
+  }
+  $destination .= "/$project";
+
+  return $destination;
 }
 
 /**

--- a/commands/update.bee.inc
+++ b/commands/update.bee.inc
@@ -166,9 +166,9 @@ function update_bee_callback($arguments) {
       return;
     }
     foreach ($data as $item) {
-      $folder = backdrop_get_path($item['project_type'], $item['name']);
+      $folder = download_get_project_destination($item['name'], $item['project_type']);
       if (is_dir($folder)) {
-         bee_delete($folder);
+        bee_delete($folder);
       }
       download_bee_callback(array('projects' => array($item['name']),), []);
       echo '';

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -248,6 +248,11 @@ options in a given file.
 - `bee help status` - Display help for the 'status' command.
 - `bee help` - Display help for 'bee' itself.
 
+#### `changelog`
+*Description:* Display the current CHANGELOG of Bee.  
+*Examples:*  
+- `bee changelog` - Output the current CHANGELOG.
+
 ### Core
 #### `download-core`
 *Description:* Download Backdrop core.  

--- a/includes/globals.inc
+++ b/includes/globals.inc
@@ -114,7 +114,7 @@ define('BEE_BOOTSTRAP_FULL', 8);
 // Current version of Bee.
 // This will normally be based on the next minor release (e.g '1.x-1.1.x-dev')
 // but will be changed briefly when a release is generated.
-define('BEE_VERSION', '1.x-1.1.0');
+define('BEE_VERSION', '1.x-1.2.x-dev');
 
 // Latest release.
 // This will be updated at each release.

--- a/includes/globals.inc
+++ b/includes/globals.inc
@@ -114,11 +114,11 @@ define('BEE_BOOTSTRAP_FULL', 8);
 // Current version of Bee.
 // This will normally be based on the next minor release (e.g '1.x-1.1.x-dev')
 // but will be changed briefly when a release is generated.
-define('BEE_VERSION', '1.x-1.1.x-dev');
+define('BEE_VERSION', '1.x-1.1.0');
 
 // Latest release.
 // This will be updated at each release.
-define('BEE_LATEST_RELEASE', '1.x-1.0.2');
+define('BEE_LATEST_RELEASE', '1.x-1.1.0');
 
 /**
  * Define constants for symbols to be used within Bee.


### PR DESCRIPTION
I created a new function to get a project's install destination and changed both download and update to use it so that they expect the project to end up in the same location.

Fixes #299.