### PR TITLE
Add support for downloading only security updates to the `update` command

### DIFF
--- a/commands/update.bee.inc
+++ b/commands/update.bee.inc
@@ -32,10 +32,12 @@ function update_bee_command() {
       'options' => array(
         'security-only' => array(
           'description' => bt('Only update modules that have security updates available.'),
+          'short' => 's',
         ),
       ),
       'examples' => array(
         'bee update' => bt('Update everything with a new release.'),
+        'bee update --security-only' => bt('Update everything that is a security update only'),
         'bee update webform tatsu' => bt('Updates the Webform module and Tatsu theme only'),
       ),
     ),
@@ -154,7 +156,7 @@ function update_bee_callback($arguments, $options) {
         unset($data[$item['name']]);
         continue;
       }
-      if (isset($options['security-only']) && $item['status'] !== UPDATE_NOT_SECURE) {
+      if ((isset($options['security-only']) || isset($options['s'])) && $item['status'] !== UPDATE_NOT_SECURE) {
         unset($data[$item['name']]);
       }
     }

--- a/commands/update.bee.inc
+++ b/commands/update.bee.inc
@@ -33,13 +33,6 @@ function update_bee_command() {
         'security-only' => array(
           'description' => bt('Only update modules that have security updates available.'),
         ),
-        'report-only' => array(
-          'description' => bt('Output a list of modules with available updates rather than updating them.'),
-        ),
-        'output-format' => array(
-          'description' => bt('Format to output update information in. Options are "table" (default), "list".'),
-          'value' => bt('Format'),
-        ),
       ),
       'examples' => array(
         'bee update' => bt('Update everything with a new release.'),
@@ -167,14 +160,22 @@ function update_bee_callback($arguments, $options) {
     }
   }
   if ($data != NULL) {
-    if (isset($options['output-format']) && $options['output-format'] === 'list') {
-      update_bee_render_list_output($data);
-    } else {
-      update_bee_render_table_output($data);
+    foreach ($data as $item) {
+      $rows[] = array(
+        array('value' => $item['name']),
+        array('value' => $item['existing_version']),
+        array('value' => $item['latest_version']),
+      );
     }
-    if (isset($options['report-only'])) {
-      return;
-    }
+    bee_render_text(array('value' => bt("These are the items being updated:\n")));
+    bee_render_table(array(
+      'rows' => $rows,
+      'header' => array(
+        array('value' => bt('Module')),
+        array('value' => bt('Existing')),
+        array('value' => bt('Latest')),
+      ),
+    ));
     // Prompt to continue.
     if (!bee_confirm(bt('Would you like to continue?'), FALSE)) {
       return;
@@ -189,30 +190,5 @@ function update_bee_callback($arguments, $options) {
     }
   } else {
     bee_message(bt('No Modules or Themes to Update'));
-  }
-}
-
-function update_bee_render_table_output($data) {
-  foreach ($data as $item) {
-    $rows[] = array(
-      array('value' => $item['name']),
-      array('value' => $item['existing_version']),
-      array('value' => $item['latest_version']),
-    );
-  }
-  bee_render_text(array('value' => bt("These are the items being updated:\n")));
-  bee_render_table(array(
-    'rows' => $rows,
-    'header' => array(
-      array('value' => bt('Module')),
-      array('value' => bt('Existing')),
-      array('value' => bt('Latest')),
-    ),
-  ));
-}
-
-function update_bee_render_list_output($data) {
-  foreach ($data as $item) {
-    bee_render_text(array('value' => $item['name']));
   }
 }

--- a/commands/update.bee.inc
+++ b/commands/update.bee.inc
@@ -26,6 +26,18 @@ function update_bee_command() {
       'bootstrap' => BEE_BOOTSTRAP_FULL,
       'optional_arguments' => array('project'),
       'multiple_argument' => 'project',
+      'options' => array(
+        'security-only' => array(
+          'description' => bt('Only update modules that have security updates available.'),
+        ),
+        'report-only' => array(
+          'description' => bt('Output a list of modules with available updates rather than updating them.'),
+        ),
+        'output-format' => array(
+          'description' => bt('Format to output update information in. Options are "table" (default), "list".'),
+          'value' => bt('Format'),
+        ),
+      ),
       'examples' => array(
         'bee update' => bt('Update everything with a new release.'),
         'bee update webform tatsu' => bt('Updates the Webform module and Tatsu theme only'),
@@ -120,7 +132,7 @@ function update_db_bee_callback() {
  * @todo  Consider a way to download first, check the download has worked before delete.
  *
  */
-function update_bee_callback() {
+function update_bee_callback($arguments, $options) {
   global $_bee_backdrop_root;
   require_once $_bee_backdrop_root . '/core/includes/file.inc';
   $data = NULL;
@@ -136,25 +148,20 @@ function update_bee_callback() {
       if ($item['existing_version'] == $item['latest_version']) {
         unset($data[$item['name']]);
       }
+      if (isset($options['security-only']) && $item['status'] !== UPDATE_NOT_SECURE) {
+        unset($data[$item['name']]);
+      }
     }
   }
   if ($data != NULL) {
-    foreach ($data as $item) {
-      $rows[] = array(
-        array('value' => $item['name']),
-        array('value' => $item['existing_version']),
-        array('value' => $item['latest_version']),
-      );
+    if (isset($options['output-format']) && $options['output-format'] === 'list') {
+      update_bee_render_list_output($data);
+    } else {
+      update_bee_render_table_output($data);
     }
-    bee_render_text(array('value' => bt("These are the items being updated:\n")));
-    bee_render_table(array(
-      'rows' => $rows,
-      'header' => array(
-        array('value' => bt('Module')),
-        array('value' => bt('Existing')),
-        array('value' => bt('Latest')),
-      ),
-    ));
+    if (isset($options['report-only'])) {
+      return;
+    }
     // Prompt to continue.
     if (!bee_confirm(bt('Would you like to continue?'), FALSE)) {
       return;
@@ -169,5 +176,30 @@ function update_bee_callback() {
     }
   } else {
     bee_message(bt('No Modules or Themes to Update'));
+  }
+}
+
+function update_bee_render_table_output($data) {
+  foreach ($data as $item) {
+    $rows[] = array(
+      array('value' => $item['name']),
+      array('value' => $item['existing_version']),
+      array('value' => $item['latest_version']),
+    );
+  }
+  bee_render_text(array('value' => bt("These are the items being updated:\n")));
+  bee_render_table(array(
+    'rows' => $rows,
+    'header' => array(
+      array('value' => bt('Module')),
+      array('value' => bt('Existing')),
+      array('value' => bt('Latest')),
+    ),
+  ));
+}
+
+function update_bee_render_list_output($data) {
+  foreach ($data as $item) {
+    bee_render_text(array('value' => $item['name']));
   }
 }


### PR DESCRIPTION
Fixes #300

Add support for downloading only security updates to the `update` command.

This adds support for a `--security-only` flag to allow updates to be run just for modules with security releases. ~~This also adds a way to report on the avaiable updates without actually running them, as well as an alternate output format that supports just listing the modules names. This mimics the behavior of `drush pm-updatestatus --format=list` which is useful for feeding the output to another process that actually runs the output, like an Ansible playbook.~~

~~I'm not sure if it makes sense to combine the `--report-only` and `--output-format` into the `update` command rather than adding a separate `updatelist` command. I started with a separate one but realized so much of the code is the same. Happy to split it out if that's preferred, though.~~