### PR TITLE
Add an update-status command.

### DIFF
--- a/commands/update.bee.inc
+++ b/commands/update.bee.inc
@@ -54,6 +54,7 @@ function update_bee_command() {
       'options' => array(
         'security-only' => array(
           'description' => bt('Only update modules that have security updates available.'),
+          'short' => 's',
         ),
         'format' => array(
           'description' => bt('Format to output update information in. Options are "table" (default), "list".'),

--- a/commands/update.bee.inc
+++ b/commands/update.bee.inc
@@ -41,6 +41,31 @@ function update_bee_command() {
         'bee update webform tatsu' => bt('Updates the Webform module and Tatsu theme only'),
       ),
     ),
+    'update-status' => array(
+      'description' => bt('Lists available updates for backdrop, modules, themes and layouts with new releases'),
+      'callback' => 'update_list_bee_callback',
+      'aliases' => array('ups', 'pm-updatestatus'),
+      'bootstrap' => BEE_BOOTSTRAP_FULL,
+      'arguments' => array(
+        'projects' => bt('One or more projects to list updates for.'),
+      ),
+      'optional_arguments' => array('projects'),
+      'multiple_argument' => 'projects',
+      'options' => array(
+        'security-only' => array(
+          'description' => bt('Only update modules that have security updates available.'),
+        ),
+        'format' => array(
+          'description' => bt('Format to output update information in. Options are "table" (default), "list".'),
+          'value' => bt('table'),
+        ),
+      ),
+      'examples' => array(
+        'bee update-status' => bt('List updates for everything with a new release.'),
+        'bee update-status --security-only' => bt('List only security updates for everything with a new release.'),
+        'bee update-status webform tatsu' => bt('List updates for the Webform module and Tatsu theme only'),
+      ),
+    ),
   );
 }
 
@@ -133,6 +158,44 @@ function update_db_bee_callback() {
 function update_bee_callback($arguments, $options) {
   global $_bee_backdrop_root;
   require_once $_bee_backdrop_root . '/core/includes/file.inc';
+  $data = update_bee_gather_available_updates($arguments, $options);
+  if ($data != NULL) {
+    update_bee_render_table_output($data);
+    // Prompt to continue.
+    if (!bee_confirm(bt('Would you like to continue?'), FALSE)) {
+      return;
+    }
+    foreach ($data as $item) {
+      $folder = backdrop_get_path($item['project_type'], $item['name']);
+      if (is_dir($folder)) {
+         bee_delete($folder);
+      }
+      download_bee_callback(array('projects' => array($item['name']),), []);
+      echo '';
+    }
+  } else {
+    bee_message(bt('No Modules or Themes to Update'));
+  }
+}
+
+/**
+ * Command callback: Show module and theme updates.
+ */
+function update_list_bee_callback($arguments, $options) {
+  $data = update_bee_gather_available_updates($arguments, $options);
+  $is_list_format = isset($options['format']) && $options['format'] === 'list';
+  if ($data === NULL && !$is_list_format) {
+    bee_message(bt('No Modules or Themes to Update'));
+    return;
+  }
+  if ($is_list_format) {
+    update_bee_render_list_output($data);
+  } else {
+    update_bee_render_table_output($data);
+  }
+}
+
+function update_bee_gather_available_updates($arguments, $options) {
   $data = NULL;
   if ($available = update_get_available(TRUE)) {
     module_load_include('inc', 'update', 'update.compare');
@@ -161,36 +224,30 @@ function update_bee_callback($arguments, $options) {
       }
     }
   }
-  if ($data != NULL) {
-    foreach ($data as $item) {
-      $rows[] = array(
-        array('value' => $item['name']),
-        array('value' => $item['existing_version']),
-        array('value' => $item['latest_version']),
-      );
-    }
-    bee_render_text(array('value' => bt("These are the items being updated:\n")));
-    bee_render_table(array(
-      'rows' => $rows,
-      'header' => array(
-        array('value' => bt('Module')),
-        array('value' => bt('Existing')),
-        array('value' => bt('Latest')),
-      ),
-    ));
-    // Prompt to continue.
-    if (!bee_confirm(bt('Would you like to continue?'), FALSE)) {
-      return;
-    }
-    foreach ($data as $item) {
-      $folder = backdrop_get_path($item['project_type'], $item['name']);
-      if (is_dir($folder)) {
-         bee_delete($folder);
-      }
-      download_bee_callback(array('projects' => array($item['name']),), []);
-      echo '';
-    }
-  } else {
-    bee_message(bt('No Modules or Themes to Update'));
+  return $data;
+}
+
+function update_bee_render_table_output($data) {
+  foreach ($data as $item) {
+    $rows[] = array(
+      array('value' => $item['name']),
+      array('value' => $item['existing_version']),
+      array('value' => $item['latest_version']),
+    );
+  }
+  bee_render_text(array('value' => bt("These are the items being updated:\n")));
+  bee_render_table(array(
+    'rows' => $rows,
+    'header' => array(
+      array('value' => bt('Module')),
+      array('value' => bt('Existing')),
+      array('value' => bt('Latest')),
+    ),
+  ));
+}
+
+function update_bee_render_list_output($data) {
+  foreach ($data as $item) {
+    bee_render_text(array('value' => $item['name']));
   }
 }

--- a/commands/update.bee.inc
+++ b/commands/update.bee.inc
@@ -41,10 +41,10 @@ function update_bee_command() {
         'bee update webform tatsu' => bt('Updates the Webform module and Tatsu theme only'),
       ),
     ),
-    'update-status' => array(
+    'update-list' => array(
       'description' => bt('Lists available updates for backdrop, modules, themes and layouts with new releases'),
       'callback' => 'update_list_bee_callback',
-      'aliases' => array('ups', 'pm-updatestatus'),
+      'aliases' => array('ups', 'pm-updatestatus', 'update-status', 'upl'),
       'bootstrap' => BEE_BOOTSTRAP_FULL,
       'arguments' => array(
         'projects' => bt('One or more projects to list updates for.'),
@@ -53,7 +53,7 @@ function update_bee_command() {
       'multiple_argument' => 'projects',
       'options' => array(
         'security-only' => array(
-          'description' => bt('Only update modules that have security updates available.'),
+          'description' => bt('Only list updates for modules that have security updates available.'),
           'short' => 's',
         ),
         'format' => array(
@@ -62,9 +62,9 @@ function update_bee_command() {
         ),
       ),
       'examples' => array(
-        'bee update-status' => bt('List updates for everything with a new release.'),
-        'bee update-status --security-only' => bt('List only security updates for everything with a new release.'),
-        'bee update-status webform tatsu' => bt('List updates for the Webform module and Tatsu theme only'),
+        'bee update-list' => bt('List updates for everything with a new release.'),
+        'bee update-list --security-only' => bt('List only security updates for everything with a new release.'),
+        'bee update-list webform tatsu' => bt('List updates for the Webform module and Tatsu theme only'),
       ),
     ),
   );
@@ -185,8 +185,10 @@ function update_bee_callback($arguments, $options) {
 function update_list_bee_callback($arguments, $options) {
   $data = update_bee_get_available_updates($arguments, $options);
   $is_list_format = isset($options['format']) && $options['format'] === 'list';
-  if ($data === NULL && !$is_list_format) {
-    bee_message(bt('No Modules or Themes to Update'));
+  if ($data == NULL) {
+    if (!$is_list_format) {
+      bee_message(bt('No Modules or Themes to Update'));
+    }
     return;
   }
   if ($is_list_format) {
@@ -231,7 +233,7 @@ function update_bee_get_available_updates($arguments, $options) {
         unset($data[$item['name']]);
         continue;
       }
-      if ((isset($options['security-only']) || isset($options['s'])) && $item['status'] !== UPDATE_NOT_SECURE) {
+      if (isset($options['security-only']) && $item['status'] !== UPDATE_NOT_SECURE) {
         unset($data[$item['name']]);
       }
     }
@@ -244,8 +246,6 @@ function update_bee_get_available_updates($arguments, $options) {
  *
  * @param array $data
  *   An array of projects with updates available.
- *
- * @return void
  */
 function update_bee_render_table_output($data) {
   foreach ($data as $item) {
@@ -271,8 +271,6 @@ function update_bee_render_table_output($data) {
  *
  * @param array $data
  *   An array of projects with updates available.
- *
- * @return void
  */
 function update_bee_render_list_output($data) {
   foreach ($data as $item) {

--- a/commands/update.bee.inc
+++ b/commands/update.bee.inc
@@ -182,7 +182,7 @@ function update_bee_callback($arguments, $options) {
 /**
  * Command callback: Show module and theme updates.
  */
-function update_list_bee_callback($arguments, $options) {
+function update_list_bee_callback(array $arguments, array $options) {
   $data = update_bee_get_available_updates($arguments, $options);
   $is_list_format = isset($options['format']) && $options['format'] === 'list';
   if ($data == NULL) {
@@ -209,7 +209,7 @@ function update_list_bee_callback($arguments, $options) {
  * @return array|NULL
  *   An array of projects with updates available, or NULL if there are none.
  */
-function update_bee_get_available_updates($arguments, $options) {
+function update_bee_get_available_updates(array $arguments, array $options) {
   $data = NULL;
   if ($available = update_get_available(TRUE)) {
     module_load_include('inc', 'update', 'update.compare');
@@ -247,7 +247,7 @@ function update_bee_get_available_updates($arguments, $options) {
  * @param array $data
  *   An array of projects with updates available.
  */
-function update_bee_render_table_output($data) {
+function update_bee_render_table_output(array $data) {
   foreach ($data as $item) {
     $rows[] = array(
       array('value' => $item['name']),
@@ -272,7 +272,7 @@ function update_bee_render_table_output($data) {
  * @param array $data
  *   An array of projects with updates available.
  */
-function update_bee_render_list_output($data) {
+function update_bee_render_list_output(array $data) {
   foreach ($data as $item) {
     bee_render_text(array('value' => $item['name']));
   }

--- a/commands/update.bee.inc
+++ b/commands/update.bee.inc
@@ -159,7 +159,7 @@ function update_db_bee_callback() {
 function update_bee_callback($arguments, $options) {
   global $_bee_backdrop_root;
   require_once $_bee_backdrop_root . '/core/includes/file.inc';
-  $data = update_bee_gather_available_updates($arguments, $options);
+  $data = update_bee_get_available_updates($arguments, $options);
   if ($data != NULL) {
     update_bee_render_table_output($data);
     // Prompt to continue.
@@ -183,7 +183,7 @@ function update_bee_callback($arguments, $options) {
  * Command callback: Show module and theme updates.
  */
 function update_list_bee_callback($arguments, $options) {
-  $data = update_bee_gather_available_updates($arguments, $options);
+  $data = update_bee_get_available_updates($arguments, $options);
   $is_list_format = isset($options['format']) && $options['format'] === 'list';
   if ($data === NULL && !$is_list_format) {
     bee_message(bt('No Modules or Themes to Update'));
@@ -196,7 +196,7 @@ function update_list_bee_callback($arguments, $options) {
   }
 }
 
-function update_bee_gather_available_updates($arguments, $options) {
+function update_bee_get_available_updates($arguments, $options) {
   $data = NULL;
   if ($available = update_get_available(TRUE)) {
     module_load_include('inc', 'update', 'update.compare');

--- a/commands/update.bee.inc
+++ b/commands/update.bee.inc
@@ -196,6 +196,17 @@ function update_list_bee_callback($arguments, $options) {
   }
 }
 
+/**
+ * Get an array of available project updates.
+ *
+ * @param array $arguments
+ *   A list of arguments passed to the command.
+ * @param array $options
+ *   A list of options passed to the command.
+ *
+ * @return array|NULL
+ *   An array of projects with updates available, or NULL if there are none.
+ */
 function update_bee_get_available_updates($arguments, $options) {
   $data = NULL;
   if ($available = update_get_available(TRUE)) {
@@ -228,6 +239,14 @@ function update_bee_get_available_updates($arguments, $options) {
   return $data;
 }
 
+/**
+ * Render available updates as a table.
+ *
+ * @param array $data
+ *   An array of projects with updates available.
+ *
+ * @return void
+ */
 function update_bee_render_table_output($data) {
   foreach ($data as $item) {
     $rows[] = array(
@@ -247,6 +266,14 @@ function update_bee_render_table_output($data) {
   ));
 }
 
+/**
+ * Render available updates as a list.
+ *
+ * @param array $data
+ *   An array of projects with updates available.
+ *
+ * @return void
+ */
 function update_bee_render_list_output($data) {
   foreach ($data as $item) {
     bee_render_text(array('value' => $item['name']));


### PR DESCRIPTION
Fixes #350. This command is similar to the `update` command but only lists the available updates. It mirrors the `drush pm-updatestatus` command. It allows for outputing a flat list of module names to feed into another process, like an ansible script. It also includes an option to list only updates that are flagged as security releases.