### PR TITLE
Check for the presence of the MySQL binaries before calling them

### DIFF
--- a/commands/db.bee.inc
+++ b/commands/db.bee.inc
@@ -121,8 +121,7 @@ function db_export_bee_callback($arguments, $options) {
 
   $export_command = executable_for('mysqldump');
   if (!$export_command) {
-    bee_message("The MySQL export command 'mysqldump' cannot be found in " .
-                "this system. Please install it and try again.", 'error');
+      bee_message(bt("The MySQL export command 'mysqldump' cannot be found in this system. Please install it and try again."), 'error');
     return FALSE;
   }
   // Export and compress the database.
@@ -180,16 +179,14 @@ function db_import_bee_callback($arguments, $options) {
   // Import the database.
   $mysql_bin = executable_for('mysql');
   if (!$mysql_bin) {
-    bee_message("The MySQL client command 'mysql' cannot be found in this " .
-                "system. Please install it and try again.", 'error');
+    bee_message(bt("The MySQL client command 'mysql' cannot be found in this system. Please install it and try again."), 'error');
     return FALSE;
   }
   $import_command = '';
   if ($gzip) {
     $gunzip_bin = executable_for('gunzip');
     if (!$gunzip_bin) {
-      bee_message("The gzip decompressor command 'gunzip' cannot be found " .
-                  "in this system. Please install it and try again.", 'error');
+      bee_message(bt("The gzip decompressor command 'gunzip' cannot be found in this system. Please install it and try again."), 'error');
       return FALSE;
     }
     $import_command .= "$gunzip_bin -c $filename | ";
@@ -238,8 +235,7 @@ function db_drop_bee_callback($arguments, $options) {
   // Drop the existing backdrop database as configured.
   $mysql_command = executable_for('mysql');
   if (!$mysql_command) {
-    bee_message("The MySQL client command 'mysql' cannot be found in this " .
-                "system. Please install it and try again.", 'error');
+    bee_message(bt("The MySQL client command 'mysql' cannot be found in this system. Please install it and try again."), 'error');
     return FALSE;
   }
   $command = $mysql_command . ' ' . $connection_string . ' -e "drop database ' . $db_database . '";';
@@ -291,8 +287,7 @@ function sql_bee_callback($arguments, $options) {
   // Open SQL command-line.
   $mysql_command = executable_for('mysql');
   if (!$mysql_command) {
-    bee_message("The MySQL client command 'mysql' cannot be found in this " .
-                "system. Please install it and try again.", 'error');
+    bee_message(bt("The MySQL client command 'mysql' cannot be found in this system. Please install it and try again."), 'error');
     return FALSE;
   }
   $command = $mysql_command . ' ' . $connection_string;

--- a/commands/db.bee.inc
+++ b/commands/db.bee.inc
@@ -119,8 +119,14 @@ function db_export_bee_callback($arguments, $options) {
     $extra = '--no-tablespaces ';
   }
 
+  $export_command = executable_for('mysqldump');
+  if (is_null($export_command)) {
+    bee_message("The MySQL export command 'mysqldump' cannot be found in " .
+                "this system. Please install it and try again.", 'error');
+    return null;
+  }
   // Export and compress the database.
-  $export_command = 'mysqldump ';
+  $export_command .= ' ';
   $export_command .= $connection_string;
   $export_command .= ' ';
   $export_command .= $extra;
@@ -172,11 +178,23 @@ function db_import_bee_callback($arguments, $options) {
   }
 
   // Import the database.
+  $mysql_bin = executable_for('mysql');
+  if (is_null($mysql_bin)) {
+    bee_message("The MySQL client command 'mysql' cannot be found in " .
+                "this system. Please install it and try again.", 'error');
+    return null;
+  }
   $import_command = '';
   if ($gzip) {
-    $import_command .= "gunzip -c $filename | ";
+    $gunzip_bin = executable_for('gunzip');
+    if (is_null($gunzip_bin)) {
+      bee_message("The gzip decompressor command 'gunzip' cannot be found in " .
+                  "this system. Please install it and try again.", 'error');
+      return null;
+    }
+    $import_command .= "$gunzip_bin -c $filename | ";
   }
-  $import_command .= 'mysql ' . $connection_string;
+  $import_command .= $mysql_bin . ' ' . $connection_string;
   if (!$gzip) {
     $import_command .= " < $filename";
   }
@@ -218,7 +236,13 @@ function db_drop_bee_callback($arguments, $options) {
   $connection_file = $connection_details['filename'];
 
   // Drop the existing backdrop database as configured.
-  $command = 'mysql ' . $connection_string . ' -e "drop database ' . $db_database . '";';
+  $mysql_command = executable_for('mysql');
+  if (is_null($mysql_command)) {
+    bee_message("The MySQL client command 'mysql' cannot be found in " .
+                "this system. Please install it and try again.", 'error');
+    return null;
+  }
+  $command = $mysql_command . ' ' . $connection_string . ' -e "drop database ' . $db_database . '";';
   $result = proc_close(proc_open($command, array(STDIN, STDOUT, STDERR), $pipes));
 
   if ($result == -1) {
@@ -233,7 +257,7 @@ function db_drop_bee_callback($arguments, $options) {
   }
 
   // Re-create the existing backdrop database as configured.
-  $command = 'mysql ' . $connection_string . ' -e "create database ' . $db_database . '";';
+  $command = $mysql_command .' ' . $connection_string . ' -e "create database ' . $db_database . '";';
   $result = proc_close(proc_open($command, array(STDIN, STDOUT, STDERR), $pipes));
 
   if ($result == -1) {
@@ -265,7 +289,13 @@ function sql_bee_callback($arguments, $options) {
   $connection_file = $connection_details['filename'];
 
   // Open SQL command-line.
-  $command = 'mysql ' . $connection_string;
+  $mysql_command = executable_for('mysql');
+  if (is_null($mysql_command)) {
+    bee_message("The MySQL client command 'mysql' cannot be found in " .
+                "this system. Please install it and try again.", 'error');
+    return null;
+  }
+  $command = $mysql_command . ' ' . $connection_string;
   proc_close(proc_open($command, array(STDIN, STDOUT, STDERR), $pipes));
   // Remove the temporary mysql options file.
   bee_delete($connection_file);
@@ -347,4 +377,18 @@ function dbq_bee_callback($arguments, $options) {
   catch (PDOException $e) {
     bee_message($e->getMessage(), 'error');
   }
+}
+
+/**
+ * Checks whether a command exists in the PATH, and if so, returns the
+ * full path. Returns null if no such command is available.
+ */
+function executable_for($cmd) {
+    foreach (explode(":", getenv('PATH')) as $dir) {
+        $candidate = "$dir/$cmd";
+        if (is_executable($candidate)) {
+            return $candidate;
+        }
+    }
+    return null;
 }

--- a/commands/db.bee.inc
+++ b/commands/db.bee.inc
@@ -119,7 +119,7 @@ function db_export_bee_callback($arguments, $options) {
     $extra = '--no-tablespaces ';
   }
 
-  $export_command = executable_for('mysqldump');
+  $export_command = bee_get_executable_path('mysqldump');
   if (!$export_command) {
       bee_message(bt("The MySQL export command 'mysqldump' cannot be found in this system. Please install it and try again."), 'error');
     return FALSE;
@@ -177,14 +177,14 @@ function db_import_bee_callback($arguments, $options) {
   }
 
   // Import the database.
-  $mysql_bin = executable_for('mysql');
+  $mysql_bin = bee_get_executable_path('mysql');
   if (!$mysql_bin) {
     bee_message(bt("The MySQL client command 'mysql' cannot be found in this system. Please install it and try again."), 'error');
     return FALSE;
   }
   $import_command = '';
   if ($gzip) {
-    $gunzip_bin = executable_for('gunzip');
+    $gunzip_bin = bee_get_executable_path('gunzip');
     if (!$gunzip_bin) {
       bee_message(bt("The gzip decompressor command 'gunzip' cannot be found in this system. Please install it and try again."), 'error');
       return FALSE;
@@ -233,7 +233,7 @@ function db_drop_bee_callback($arguments, $options) {
   $connection_file = $connection_details['filename'];
 
   // Drop the existing backdrop database as configured.
-  $mysql_command = executable_for('mysql');
+  $mysql_command = bee_get_executable_path('mysql');
   if (!$mysql_command) {
     bee_message(bt("The MySQL client command 'mysql' cannot be found in this system. Please install it and try again."), 'error');
     return FALSE;
@@ -285,7 +285,7 @@ function sql_bee_callback($arguments, $options) {
   $connection_file = $connection_details['filename'];
 
   // Open SQL command-line.
-  $mysql_command = executable_for('mysql');
+  $mysql_command = bee_get_executable_path('mysql');
   if (!$mysql_command) {
     bee_message(bt("The MySQL client command 'mysql' cannot be found in this system. Please install it and try again."), 'error');
     return FALSE;
@@ -372,25 +372,4 @@ function dbq_bee_callback($arguments, $options) {
   catch (PDOException $e) {
     bee_message($e->getMessage(), 'error');
   }
-}
-
-/**
- * Checks whether a command exists in the PATH, and if so, returns the full
- * path. Returns FALSE if no such command is available.
- *
- * @param string $cmd
- *   Name of the command to be searched.
- *
- * @return string
- *   Full path to the first occurence of $cmd in the search path.
- *   Returns FALSE if no matching command is found.
- */
-function executable_for($cmd) {
-  foreach (explode(":", getenv('PATH')) as $dir) {
-    $candidate = "$dir/$cmd";
-    if (is_executable($candidate)) {
-      return $candidate;
-    }
-  }
-  return FALSE;
 }

--- a/commands/db.bee.inc
+++ b/commands/db.bee.inc
@@ -180,16 +180,16 @@ function db_import_bee_callback($arguments, $options) {
   // Import the database.
   $mysql_bin = executable_for('mysql');
   if (is_null($mysql_bin)) {
-    bee_message("The MySQL client command 'mysql' cannot be found in " .
-                "this system. Please install it and try again.", 'error');
+    bee_message("The MySQL client command 'mysql' cannot be found in this " .
+                "system. Please install it and try again.", 'error');
     return null;
   }
   $import_command = '';
   if ($gzip) {
     $gunzip_bin = executable_for('gunzip');
     if (is_null($gunzip_bin)) {
-      bee_message("The gzip decompressor command 'gunzip' cannot be found in " .
-                  "this system. Please install it and try again.", 'error');
+      bee_message("The gzip decompressor command 'gunzip' cannot be found " .
+                  "in this system. Please install it and try again.", 'error');
       return null;
     }
     $import_command .= "$gunzip_bin -c $filename | ";
@@ -238,8 +238,8 @@ function db_drop_bee_callback($arguments, $options) {
   // Drop the existing backdrop database as configured.
   $mysql_command = executable_for('mysql');
   if (is_null($mysql_command)) {
-    bee_message("The MySQL client command 'mysql' cannot be found in " .
-                "this system. Please install it and try again.", 'error');
+    bee_message("The MySQL client command 'mysql' cannot be found in this " .
+                "system. Please install it and try again.", 'error');
     return null;
   }
   $command = $mysql_command . ' ' . $connection_string . ' -e "drop database ' . $db_database . '";';
@@ -291,8 +291,8 @@ function sql_bee_callback($arguments, $options) {
   // Open SQL command-line.
   $mysql_command = executable_for('mysql');
   if (is_null($mysql_command)) {
-    bee_message("The MySQL client command 'mysql' cannot be found in " .
-                "this system. Please install it and try again.", 'error');
+    bee_message("The MySQL client command 'mysql' cannot be found in this " .
+                "system. Please install it and try again.", 'error');
     return null;
   }
   $command = $mysql_command . ' ' . $connection_string;
@@ -380,15 +380,15 @@ function dbq_bee_callback($arguments, $options) {
 }
 
 /**
- * Checks whether a command exists in the PATH, and if so, returns the
- * full path. Returns null if no such command is available.
+ * Checks whether a command exists in the PATH, and if so, returns the full
+ * path. Returns null if no such command is available.
  */
 function executable_for($cmd) {
-    foreach (explode(":", getenv('PATH')) as $dir) {
-        $candidate = "$dir/$cmd";
-        if (is_executable($candidate)) {
-            return $candidate;
-        }
+  foreach (explode(":", getenv('PATH')) as $dir) {
+    $candidate = "$dir/$cmd";
+    if (is_executable($candidate)) {
+      return $candidate;
     }
-    return null;
+  }
+  return null;
 }

--- a/commands/db.bee.inc
+++ b/commands/db.bee.inc
@@ -120,10 +120,10 @@ function db_export_bee_callback($arguments, $options) {
   }
 
   $export_command = executable_for('mysqldump');
-  if (is_null($export_command)) {
+  if (!$export_command) {
     bee_message("The MySQL export command 'mysqldump' cannot be found in " .
                 "this system. Please install it and try again.", 'error');
-    return null;
+    return FALSE;
   }
   // Export and compress the database.
   $export_command .= ' ';
@@ -179,18 +179,18 @@ function db_import_bee_callback($arguments, $options) {
 
   // Import the database.
   $mysql_bin = executable_for('mysql');
-  if (is_null($mysql_bin)) {
+  if (!$mysql_bin) {
     bee_message("The MySQL client command 'mysql' cannot be found in this " .
                 "system. Please install it and try again.", 'error');
-    return null;
+    return FALSE;
   }
   $import_command = '';
   if ($gzip) {
     $gunzip_bin = executable_for('gunzip');
-    if (is_null($gunzip_bin)) {
+    if (!$gunzip_bin) {
       bee_message("The gzip decompressor command 'gunzip' cannot be found " .
                   "in this system. Please install it and try again.", 'error');
-      return null;
+      return FALSE;
     }
     $import_command .= "$gunzip_bin -c $filename | ";
   }
@@ -237,10 +237,10 @@ function db_drop_bee_callback($arguments, $options) {
 
   // Drop the existing backdrop database as configured.
   $mysql_command = executable_for('mysql');
-  if (is_null($mysql_command)) {
+  if (!$mysql_command) {
     bee_message("The MySQL client command 'mysql' cannot be found in this " .
                 "system. Please install it and try again.", 'error');
-    return null;
+    return FALSE;
   }
   $command = $mysql_command . ' ' . $connection_string . ' -e "drop database ' . $db_database . '";';
   $result = proc_close(proc_open($command, array(STDIN, STDOUT, STDERR), $pipes));
@@ -290,10 +290,10 @@ function sql_bee_callback($arguments, $options) {
 
   // Open SQL command-line.
   $mysql_command = executable_for('mysql');
-  if (is_null($mysql_command)) {
+  if (!$mysql_command) {
     bee_message("The MySQL client command 'mysql' cannot be found in this " .
                 "system. Please install it and try again.", 'error');
-    return null;
+    return FALSE;
   }
   $command = $mysql_command . ' ' . $connection_string;
   proc_close(proc_open($command, array(STDIN, STDOUT, STDERR), $pipes));
@@ -381,7 +381,14 @@ function dbq_bee_callback($arguments, $options) {
 
 /**
  * Checks whether a command exists in the PATH, and if so, returns the full
- * path. Returns null if no such command is available.
+ * path. Returns FALSE if no such command is available.
+ *
+ * @param string $cmd
+ *   Name of the command to be searched
+ *
+ * @return string
+ *   Full path to the first occurence of $cmd in the search path.
+ *   Returns FALSE if no matching command is found.
  */
 function executable_for($cmd) {
   foreach (explode(":", getenv('PATH')) as $dir) {
@@ -390,5 +397,5 @@ function executable_for($cmd) {
       return $candidate;
     }
   }
-  return null;
+  return FALSE;
 }

--- a/commands/db.bee.inc
+++ b/commands/db.bee.inc
@@ -379,7 +379,7 @@ function dbq_bee_callback($arguments, $options) {
  * path. Returns FALSE if no such command is available.
  *
  * @param string $cmd
- *   Name of the command to be searched
+ *   Name of the command to be searched.
  *
  * @return string
  *   Full path to the first occurence of $cmd in the search path.

--- a/includes/filesystem.inc
+++ b/includes/filesystem.inc
@@ -373,3 +373,29 @@ function bee_copy($source, $destination, $self = TRUE) {
 
   return TRUE;
 }
+
+/**
+ * Get the full path for a command executable if it exists in PATH.
+ *
+ * If your function calls an executable on the system rather than using `bee`,
+ * `backdrop` or `php` functions, you can use this function to get the full
+ * path of the executable or return FALSE if the executable doesn't exist. The
+ * result can then be checked in your calling function, and you can exit with a
+ * user friendly error message if the executable doesn't exist in the system.
+ *
+ * @param string $command
+ *   Name of the command to be searched.
+ *
+ * @return string|FALSE
+ *   Full path to the first occurence of $command in the search path.
+ *   Returns FALSE if no matching command is found.
+ */
+function bee_get_executable_path($command) {
+  foreach (explode(":", getenv('PATH')) as $directory) {
+    $candidate = "$directory/$command";
+    if (is_executable($candidate)) {
+      return $candidate;
+    }
+  }
+  return FALSE;
+}


### PR DESCRIPTION
Fixes #388 
Patch to verify for the presence of `mysql` and `mysqldump` (and `gunzip`, as it was in the same command construction) before actually calling it.

Thanks!