### PR TITLE
Fix notice or warning for long column values in table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project follows the
 which is based on the major version of Backdrop CMS with a semantic version
 system for each contributed module, theme and layout.
 
-## [Unreleased]
+## [Unreleased] - 2024-09-03
 
 ### Added
 - A new function to check whether or not an executable exists in the system.
@@ -39,6 +39,8 @@ not exist.
 - Unhandled Warning if argument for 'cache-clear' wasn't in the list.
 - Error if config-set used to set a new configuration item.
 - Unhandled Warning on `user-create` with mail option.
+- Notice/Warning when long values (e.g. long module names, long config
+filenames) are included in table output.
 
 ## [1.x-1.0.2] - 2024-05-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project follows the
 which is based on the major version of Backdrop CMS with a semantic version
 system for each contributed module, theme and layout.
 
-## [Unreleased] - 2024-09-03
+## [Unreleased] - 2024-09-06
 
 ### Added
 - A new function to check whether or not an executable exists in the system.

--- a/includes/render.inc
+++ b/includes/render.inc
@@ -360,6 +360,7 @@ function bee_get_column_widths($rows, $header, $delimiter, $delimiter_left, $del
       }
     }
   }
+  bee_instant_message(bt('Column widths:'), 'debug', $widths);
 
   // Get the widest column, and calculate the width of the table.
   $widest_column = 0;
@@ -379,6 +380,7 @@ function bee_get_column_widths($rows, $header, $delimiter, $delimiter_left, $del
   // SSH command) then 'tput cols' on its own will create an error. This
   // provides an alternative if 'tput cols' create an error.
   $terminal_width = exec('if tput cols &>/dev/null; then  echo $(tput cols); else $(echo $COLUMNS); fi');
+  bee_instant_message(bt('The terminal width is: ') . $terminal_width, 'debug');
   if ($terminal_width && $table_width > $terminal_width) {
     $diff = $table_width - $terminal_width;
     $widths[$widest_column] -= $diff;
@@ -432,7 +434,7 @@ function bee_get_remaining_rows(array $row, array $column_widths) {
   $row_rendered = array();
 
   foreach ($column_widths as $index => $width) {
-    if ($index == $row['index']) {
+    if ($row && $index == $row['index']) {
       $column = $row;
 
       if (mb_strlen((string) $column['value']) > $width) {


### PR DESCRIPTION
Fixes #430 and Fixes #360 

I've added a couple of debug messages into the function too; one for outputting the column widths and one for the terminal width; just add `-d` or `--debug` to your command to see them.