### PR TITLE
Issue #467: Add support for enabling modules and themes via bee cim.

### DIFF
--- a/commands/config.bee.inc
+++ b/commands/config.bee.inc
@@ -299,6 +299,25 @@ function config_import_bee_callback($arguments, $options) {
     return;
   }
 
+  // As of Backdrop 1.32.0, modules and themes may be enabled via config import.
+  // Import the special system.extensions config file first if it exists.
+  if (isset($statuses['system.extensions']) && $statuses['system.extensions'] == 'update') {
+    config_sync_file('system.extensions', 'update');
+
+    // Revalidate the configuration after new modules have been enabled.
+    // Hooks such as hook_config_import_validate() in the newly enabled modules
+    // will be included as module_enable() clears the module_implements() cache.
+    try {
+      foreach ($rows as $row) {
+        config_sync_validate_file($row[0]['value'], $row[1]['value'], $statuses);
+      }
+    }
+    catch (ConfigValidateException $e) {
+      bee_message($e->getMessage(), 'error');
+      return;
+    }
+  }
+
   // Import config.
   foreach ($rows as $row) {
     config_sync_file($row[0]['value'], $row[1]['value']);


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/bee/issues/467

Backdrop 1.32.0 will be able to enable modules and themes via config after https://github.com/backdrop/backdrop-issues/issues/5163.

This PR updates the `bee cim` command to take into account the new `system.extensions.json` config file and the special treatment needed to support it.

To test:

- Make sure your local is running the latest version of Backdrop 1.x from a Git checkout (i.e. `1.32.x-dev` version)
- Run `bee updb` if needed to create the `system.extensions.json` file.
- Export current configuration with `bee cex`
- Find your staging directory and modify the `system.extensions.json` file. In my testing I added a line for `contact: true` to enable Contact module.
- Run `bee cim` to import the modified `system.extensions.json` file.
- Confirm Contact module has been enabled.
